### PR TITLE
Update build.gradle (compile 'com.facebook.react:react-native:+')

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,5 +19,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.33.+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
We don't have to limit our react-native version to a specific one. This will only give us an error after the RN upgrade.
