### PR TITLE
Clear shared text (Android)

### DIFF
--- a/android/src/main/java/com/meedan/ShareMenuModule.java
+++ b/android/src/main/java/com/meedan/ShareMenuModule.java
@@ -34,4 +34,11 @@ public class ShareMenuModule extends ReactContextBaseJavaModule {
     String inputText = intent.getStringExtra(Intent.EXTRA_TEXT);
     successCallback.invoke(inputText);
   }
+
+  @ReactMethod
+  public void clearSharedText() {
+    Activity mActivity = getCurrentActivity();
+    Intent intent = mActivity.getIntent();
+    intent.removeExtra(Intent.EXTRA_TEXT);
+  }
 }


### PR DESCRIPTION
In my application I'm checking for the presence of shared text when the app changes into the active state using the ```AppState``` API. Because the native Android activity is reused between launches, the old shared text can hang around and its not possible to know whether you've already handled it without storing it somewhere.

It seemed appropriate to me to be able to clear this text one you've handled it. To achieve that I've added a new API method:

```
ShareMenu.clearSharedText();
```

I haven't yet implemented this on iOS because I'm not sure if the same scenario is relevant and I'm currently only working in Android. If you can advise I can add the change here too.