### PR TITLE
Add automatic installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ npm i --save react-native-share-menu
 
 ## Usage in Android
 
+### Automatic Installation (React Native 0.36+)
+
+At the command line, in the project directory:
+
+```bash
+react-native link
+```
+
+### Manual Installation
+
 * In `android/settings.gradle`
 
 ```gradle


### PR DESCRIPTION
The new `react-native link` command works perfectly with the library and requires no additional configuration. This commit adds instructions for automatic installation to the README 😄 .