### PR TITLE
Added support for sharing images

### DIFF
--- a/android/src/main/java/com/meedan/ShareMenuModule.java
+++ b/android/src/main/java/com/meedan/ShareMenuModule.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.net.Uri;
 
 public class ShareMenuModule extends ReactContextBaseJavaModule {
 
@@ -29,14 +30,30 @@ public class ShareMenuModule extends ReactContextBaseJavaModule {
   public void getSharedText(Callback successCallback) {
     Activity mActivity = getCurrentActivity();
     Intent intent = mActivity.getIntent();
-    String inputText = intent.getStringExtra(Intent.EXTRA_TEXT);
-    successCallback.invoke(inputText);
+    String action = intent.getAction();
+    String type = intent.getType();
+
+    if (Intent.ACTION_SEND.equals(action) && type != null) {
+      if ("text/plain".equals(type)) {
+        String input = intent.getStringExtra(Intent.EXTRA_TEXT);
+        successCallback.invoke(input);
+      }
+      else if (type.startsWith("image/")) {
+        Uri imageUri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
+        successCallback.invoke(imageUri.toString());
+      }
+    }
   }
 
   @ReactMethod
   public void clearSharedText() {
     Activity mActivity = getCurrentActivity();
     Intent intent = mActivity.getIntent();
-    intent.removeExtra(Intent.EXTRA_TEXT);
+    String type = intent.getType();
+    if ("text/plain".equals(type)) {
+      intent.removeExtra(Intent.EXTRA_TEXT);
+    } else if (type.startsWith("image/")) {
+      intent.removeExtra(Intent.EXTRA_STREAM);
+    }
   }
 }

--- a/android/src/main/java/com/meedan/ShareMenuModule.java
+++ b/android/src/main/java/com/meedan/ShareMenuModule.java
@@ -12,14 +12,18 @@ import com.meedan.ShareMenuPackage;
 import java.util.Map;
 import java.util.ArrayList;
 
+import android.widget.Toast;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 
 public class ShareMenuModule extends ReactContextBaseJavaModule {
 
+  private ReactContext mReactContext;
+
   public ShareMenuModule(ReactApplicationContext reactContext) {
     super(reactContext);
+    mReactContext = reactContext;
   }
 
   @Override
@@ -38,10 +42,11 @@ public class ShareMenuModule extends ReactContextBaseJavaModule {
       if ("text/plain".equals(type)) {
         String input = intent.getStringExtra(Intent.EXTRA_TEXT);
         successCallback.invoke(input);
-      }
-      else if (type.startsWith("image/")) {
+      } else if (type.startsWith("image/")) {
         Uri imageUri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
         successCallback.invoke(imageUri.toString());
+      } else {
+        Toast.makeText(mReactContext, "Type is not support", Toast.LENGTH_SHORT).show();
       }
     } else if (Intent.ACTION_SEND_MULTIPLE.equals(action) && type != null) {
         if (type.startsWith("image/")) {
@@ -53,6 +58,8 @@ public class ShareMenuModule extends ReactContextBaseJavaModule {
             }
             successCallback.invoke(completeString);
           }
+        } else {
+          Toast.makeText(mReactContext, "Type is not support", Toast.LENGTH_SHORT).show();
         }
     }
   }

--- a/android/src/main/java/com/meedan/ShareMenuModule.java
+++ b/android/src/main/java/com/meedan/ShareMenuModule.java
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.Callback;
 import com.meedan.ShareMenuPackage;
 
 import java.util.Map;
+import java.util.ArrayList;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -42,6 +43,17 @@ public class ShareMenuModule extends ReactContextBaseJavaModule {
         Uri imageUri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
         successCallback.invoke(imageUri.toString());
       }
+    } else if (Intent.ACTION_SEND_MULTIPLE.equals(action) && type != null) {
+        if (type.startsWith("image/")) {
+          ArrayList<Uri> imageUris = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
+          if (imageUris != null) {
+            String completeString = new String();
+            for (Uri uri: imageUris) {
+              completeString += uri.toString() + ",";
+            }
+            successCallback.invoke(completeString);
+          }
+        }
     }
   }
 

--- a/example/index.ios.js
+++ b/example/index.ios.js
@@ -29,15 +29,12 @@ class ExampleApp extends Component {
       if (text && text.length) {
         that.setState({ sharedText: text });
       }
-
-
     });
   }
 
   _invoke() {
     this.ShareExtension.invokeToTheHostApp();
   }
-
 
   render() {
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-share-menu",
   "description": "Adds the app to share menu, so it can be launched from share menu and receive data from other apps",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/meedan/react-native-share-menu.git"


### PR DESCRIPTION
I've added support for sharing images into a React Native app. 

Howto:
* Add intent-filter for images into activity:

```
<intent-filter>
  <action android:name="android.intent.action.SEND" />
  <category android:name="android.intent.category.DEFAULT" />
  <data android:mimeType="image/*" />
</intent-filter>
```

* Add support in your React Native app to catch the shared image from outside your app and process him:

```
componentWillMount() {
  var that = this;
  ShareMenu.getSharedText((text :string) => {

    if (text && text.length) {

      if (text.startsWith('content://media/')) {

        // `text` contains the local file URL to the shared image

      } else {

        // `text` contains another string (probably text)

      }
  })
}
```
