### PR TITLE
Adding an index.ios.js file

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -1,0 +1,2 @@
+var { NativeModules } = require('react-native');
+module.exports = NativeModules.ShareMenu;


### PR DESCRIPTION
## WHAT THIS PR DOES
I literally just added the same code from `index.android.js` into the newly created `index.ios.js` because every time we installed, we had to do so manually. We're only using this library for Android currently, but we cannot run the app if this iOS file does not exist. 

## HOW TO TEST THIS PR
When you `npm install` or `yarn install` and run on iOS, you should be able to do so without an error telling you that this file does not exist. 

## ADDITIONAL INFORMATION
I just wanted to help out with this PR, hope it can help other folks -- thanks for all your great work on this library!! 

## COMMIT HISTORY
- adding index.ios.js so that i don't have to manually add every time i install.