### PR TITLE
[ios 13] Swipe to dismiss issues

### DIFF
--- a/ios/ReactShareViewController.swift
+++ b/ios/ReactShareViewController.swift
@@ -49,7 +49,8 @@ class ReactShareViewController: ShareViewController, RCTBridgeDelegate, ReactSha
     ShareMenuReactView.attachViewDelegate(self)
   }
 
-  override func viewWillDisappear(_ animated: Bool) {
+  override func viewDidDisappear(_ animated: Bool) {
+    cancel()
     ShareMenuReactView.detachViewDelegate()
   }
 


### PR DESCRIPTION
Hi, I got 2 problems with swipe to dismiss
1. When start swiping down, `viewWillDisappear` is triggered, so `ShareMenuReactView` detach the delegate. If user cancel swipe down, the share view still showing but the delegate already detached.
-> **Solution**: detach delegate in `viewDidDisappear`
2. When the share view is dismissed by swiping down, I press the app again to start sharing, but share view could not load react-native view (just white screen). That is because we haven't completed/cancelled the previous process.
-> **Solution**: Call `cancel()` on `viewDidDisappear`