### PR TITLE
Updated IOS_INSTRUCTIONS.md to prevent a common pitfall around schema match

### DIFF
--- a/IOS_INSTRUCTIONS.md
+++ b/IOS_INSTRUCTIONS.md
@@ -97,6 +97,7 @@ Add the following to your app's `Info.plist` (if you already had other URL Schem
         <key>CFBundleURLSchemes</key>
         <array>
             <string>A_URL_SCHEME_UNIQUE_TO_YOUR_APP</string>
+            <!-- This url scheme doesn't contain :// at the end - E.G. "mycustomscheme"-->
         </array>
     </dict>
 </array>
@@ -109,6 +110,7 @@ Add the following to your Share Extension's `Info.plist`:
 <string>YOUR_APP_TARGET_BUNDLE_ID</string>
 <key>HostAppURLScheme</key>
 <string>YOUR_APP_URL_SCHEME_DEFINED_ABOVE</string>
+<!-- This url scheme CONTAINS :// at the end - E.G. "mycustomscheme://"-->
 <key>NSExtension</key>
 <dict>
     <key>NSExtensionAttributes</key>


### PR DESCRIPTION
The schema in Info.plist for the main project doesn't include a :// at the end while the schema in Share Extension plist file does. This is not documented anywhere - you might spend a lot of time wondering why it doesn't work before looking at the example repository to figure it out. I have added a couple of comments to make this clear.

PS: Improvements are welcome :)

PPS: Thanks to the contributors for maintaining this :)