### PR TITLE
🔧  Fix Android getSharedText nullpointer crash

### DIFF
--- a/android/src/main/java/com/meedan/ShareMenuModule.java
+++ b/android/src/main/java/com/meedan/ShareMenuModule.java
@@ -89,7 +89,6 @@ public class ShareMenuModule extends ReactContextBaseJavaModule implements Activ
     Activity currentActivity = getCurrentActivity();
 
     if (currentActivity == null) {
-      successCallback.invoke(null);
       return;
     }
 


### PR DESCRIPTION
I have been seeing more and more crashes relating to this issue: https://github.com/meedan/react-native-share-menu/issues/104

I noted that as of yet nobody made a PR for it yet so here you go! 
If there is any issue with this callback being removed please let me know but as far as I can tell, it will always cause an exception as the callback expects a map. 

