### PR TITLE
Fix background color in custom share view on iOS

### DIFF
--- a/SHARE_EXTENSION_VIEW.md
+++ b/SHARE_EXTENSION_VIEW.md
@@ -47,13 +47,13 @@ Open your Share Extension's `Info.plist` and add the following:
 <key>ReactShareViewBackgroundColor</key>
 <dict>
     <key>Red</key>
-    <integer>1</integer>
+    <real>1</real>
     <key>Green</key>
-    <integer>1</integer>
+    <real>1</real>
     <key>Blue</key>
-    <integer>1</integer>
+    <real>1</real>
     <key>Alpha</key>
-    <integer>1</integer>
+    <real>1</real>
     <key>Transparent</key>
     <false/>
 </dict>

--- a/ios/ReactShareViewController.swift
+++ b/ios/ReactShareViewController.swift
@@ -36,10 +36,10 @@ class ReactShareViewController: ShareViewController, RCTBridgeDelegate, ReactSha
         break backgroundColorSetup
       }
 
-      let red = backgroundColorConfig[COLOR_RED_KEY] as? Float ?? 1
-      let green = backgroundColorConfig[COLOR_GREEN_KEY] as? Float ?? 1
-      let blue = backgroundColorConfig[COLOR_BLUE_KEY] as? Float ?? 1
-      let alpha = backgroundColorConfig[COLOR_ALPHA_KEY] as? Float ?? 1
+      let red = (backgroundColorConfig[COLOR_RED_KEY] as? NSNumber)?.floatValue ?? 1
+      let green = (backgroundColorConfig[COLOR_GREEN_KEY] as? NSNumber)?.floatValue ?? 1
+      let blue = (backgroundColorConfig[COLOR_BLUE_KEY] as? NSNumber)?.floatValue ?? 1
+      let alpha = (backgroundColorConfig[COLOR_ALPHA_KEY] as? NSNumber)?.floatValue ?? 1
 
       rootView.backgroundColor = UIColor(red: CGFloat(red), green: CGFloat(green), blue: CGFloat(blue), alpha: CGFloat(alpha))
     }


### PR DESCRIPTION
This PR fixes an issue where the background color set through the Info.plist no longer works for iOS custom share views. It seems that the reason is in newer versions of Swift (>= `4.1`), `NSNumber` (which is the type stored for rgba values in Info.plist) can no longer be directly cast as `Float`. With this PR, these values are now cast correctly, making the background colors work once again for the custom share view. 