### PR TITLE
Fix: Sharing an image results in a fatal error

### DIFF
--- a/ios/Modules/ShareMenuReactView.swift
+++ b/ios/Modules/ShareMenuReactView.swift
@@ -126,7 +126,7 @@ public class ShareMenuReactView: NSObject {
                         semaphore.wait()
                     } else if provider.hasItemConformingToTypeIdentifier(kUTTypeImage as String) {
                         provider.loadItem(forTypeIdentifier: kUTTypeImage as String, options: nil) { (item, error) in
-                            let imageUrl: URL! = item as? URL
+                            var imageUrl: URL! = item as? URL
 
                             if (imageUrl != nil) {
                                 if let imageData = try? Data(contentsOf: imageUrl) {
@@ -139,15 +139,19 @@ public class ShareMenuReactView: NSObject {
                                     let imageData: Data! = image.pngData();
 
                                     // Creating temporary URL for image data (UIImage)
-                                    guard let imageURL = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("TemporaryScreenshot.png") else {
+                                    let tmpDir = NSTemporaryDirectory()
+                                    let tmpFilename = NSUUID().uuidString + ".jpg"
+                                    imageUrl = NSURL.fileURL(withPathComponents: [tmpDir, tmpFilename])
+
+                                    if imageUrl == nil {
                                         return
                                     }
 
                                     do {
                                         // Writing the image to the URL
-                                        try imageData.write(to: imageURL)
+                                        try imageData.write(to: imageUrl)
 
-                                        results.append([DATA_KEY: imageUrl.absoluteString, MIME_TYPE_KEY: imageURL.extractMimeType()])
+                                        results.append([DATA_KEY: imageUrl.absoluteString, MIME_TYPE_KEY: imageUrl.extractMimeType()])
                                     } catch {
                                         callback(nil, NSException(name: NSExceptionName(rawValue: "Error"), reason:"Can't load image", userInfo:nil))
                                     }


### PR DESCRIPTION
This PR addresses an important issue where sharing image data derived from a `UIImage` will encounter a fatal error (`Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value imageUrl.absoulteString`). The reason for this issue is that there is an erroneous reference to `imageUrl.absoluteString`, whereas it should be `imageURL.absoluteString` since `imageURL` is the actual `NSURL` instance. This PR gets rid of the extra `imageURL` var to reduce confusion between that and `imageUrl`.