### PR TITLE
Text Selection actions with ACTION_PROCESS_TEXT

### DIFF
--- a/android/src/main/java/com/meedan/ShareMenuModule.java
+++ b/android/src/main/java/com/meedan/ShareMenuModule.java
@@ -79,6 +79,9 @@ public class ShareMenuModule extends ReactContextBaseJavaModule implements Activ
         data.putArray(DATA_KEY, uriArr);
         return data;
       }
+    } else if (Intent.ACTION_PROCESS_TEXT.equals(action)) {
+      data.putString(DATA_KEY, intent.getStringExtra(Intent.EXTRA_PROCESS_TEXT));
+      return data;
     }
 
     return null;


### PR DESCRIPTION
Android lets you select any text outside of your app and call from that context. 
https://medium.com/androiddevelopers/custom-text-selection-actions-with-action-process-text-191f792d2999 

You can do that by modifying `AndroidManifest.xml`
```
<intent-filter>
          <action android:name="android.intent.action.PROCESS_TEXT" />
          <category android:name="android.intent.category.DEFAULT" />
          <data android:mimeType="text/plain" />
        </intent-filter>
```
and the endpoint of ShareMenuModule.java