### PR TITLE
Enabled having a different group identifier that is not the app identifier

### DIFF
--- a/IOS_INSTRUCTIONS.md
+++ b/IOS_INSTRUCTIONS.md
@@ -82,7 +82,7 @@ Create an App Group to be able to share data between your extension and your app
 
 ![Add App Groups](screenshots/Xcode-05.png)
 
-At the bottom of the window on Xcode you should see an `App Groups` section. Press the `+` button and add a group named `group.YOUR_APP_BUNDLE_ID`.
+At the bottom of the window on Xcode you should see an `App Groups` section. Press the `+` button and add a group named `group.AN_APP_BUNDLE_ID`.
 
 Repeat this process for the Share Extension target, with the exact same group name.
 
@@ -101,13 +101,17 @@ Add the following to your app's `Info.plist` (if you already had other URL Schem
         </array>
     </dict>
 </array>
+<key>HostAppBundleIdentifier</key>
+<string>YOUR_APP_GROUP_IDENTIFIER_WITHOUT_GROUP_AND_POINT</string>
+<!-- This is the app group identifier without "group." - E.G. for app group "group.com.myapp" : "com.myapp" -->
 ```
 
 Add the following to your Share Extension's `Info.plist`:
 
 ```OpenStep Property List
 <key>HostAppBundleIdentifier</key>
-<string>YOUR_APP_TARGET_BUNDLE_ID</string>
+<string>YOUR_APP_GROUP_IDENTIFIER_WITHOUT_GROUP_AND_POINT</string>
+<!-- This is the app group identifier without "group." - E.G. for app group "group.com.myapp" : "com.myapp" -->
 <key>HostAppURLScheme</key>
 <string>YOUR_APP_URL_SCHEME_DEFINED_ABOVE</string>
 <!-- This url scheme CONTAINS :// at the end - E.G. "mycustomscheme://"-->

--- a/ios/Modules/ShareMenu.swift
+++ b/ios/Modules/ShareMenu.swift
@@ -83,7 +83,7 @@ class ShareMenu: RCTEventEmitter {
         }
 
         guard let scheme = url.scheme, scheme == targetUrlScheme else { return }
-        guard let bundleId = Bundle.main.bundleIdentifier else { return }
+        guard let bundleId = Bundle.main.object(forInfoDictionaryKey: HOST_APP_IDENTIFIER_INFO_PLIST_KEY) else { return }
         guard let userDefaults = UserDefaults(suiteName: "group.\(bundleId)") else {
             print("Error: \(NO_APP_GROUP_ERROR)")
             return
@@ -102,7 +102,7 @@ class ShareMenu: RCTEventEmitter {
     func getSharedText(callback: RCTResponseSenderBlock) {
         var data = [DATA_KEY: sharedData] as [String: Any]
 
-        if let bundleId = Bundle.main.bundleIdentifier, let userDefaults = UserDefaults(suiteName: "group.\(bundleId)") {
+        if let bundleId = Bundle.main.object(forInfoDictionaryKey: HOST_APP_IDENTIFIER_INFO_PLIST_KEY), let userDefaults = UserDefaults(suiteName: "group.\(bundleId)") {
             data[EXTRA_DATA_KEY] = userDefaults.object(forKey: USER_DEFAULTS_EXTRA_DATA_KEY) as? [String: Any]
         } else {
             print("Error: \(NO_APP_GROUP_ERROR)")


### PR DESCRIPTION
Updated the module code for iOs to use a provided group app name in the app Info.plist (and the actual extension's Info.plist) that is different from the bundle identifier. 
(Updated documentation for that)