### PR TITLE
Fix crashing when sharing a screenshot

### DIFF
--- a/ios/Modules/ShareMenuReactView.swift
+++ b/ios/Modules/ShareMenuReactView.swift
@@ -147,7 +147,7 @@ public class ShareMenuReactView: NSObject {
                                         // Writing the image to the URL
                                         try imageData.write(to: imageURL)
 
-                                        results.append([DATA_KEY: imageUrl.absoluteString, MIME_TYPE_KEY: imageURL.extractMimeType()])
+                                        results.append([DATA_KEY: imageURL.absoluteString, MIME_TYPE_KEY: imageURL.extractMimeType()])
                                     } catch {
                                         callback(nil, NSException(name: NSExceptionName(rawValue: "Error"), reason:"Can't load image", userInfo:nil))
                                     }


### PR DESCRIPTION
Fix crashing issues when sharing a screenshot.
It is caused by referencing an incorrect variable.

<img width="1388" alt="Screenshot 2023-03-17 at 16 49 43" src="https://user-images.githubusercontent.com/17006912/225890587-1ace7167-599c-448f-baf0-04b88fa44bae.png">
