### PR TITLE
Add isExtension to ShareMenuReactView

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,10 @@ export const ShareMenuReactView = {
   dismissExtension(error = null) {
     NativeModules.ShareMenuReactView.dismissExtension(error);
   },
-  isExtension: NativeModules.ShareMenuReactView.isExtension,
+  isExtension: !!(
+    NativeModules.ShareMenuReactView &&
+    NativeModules.ShareMenuReactView.isExtension
+  ),
   openApp() {
     NativeModules.ShareMenuReactView.openApp();
   },

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { NativeModules, NativeEventEmitter } from "react-native";
+import { NativeEventEmitter, NativeModules } from "react-native";
 
 const { ShareMenu } = NativeModules;
 
@@ -7,17 +7,18 @@ const EventEmitter = new NativeEventEmitter(ShareMenu);
 const NEW_SHARE_EVENT_NAME = "NewShareEvent";
 
 export const ShareMenuReactView = {
-  dismissExtension(error = null) {
-    NativeModules.ShareMenuReactView.dismissExtension(error);
-  },
-  openApp() {
-    NativeModules.ShareMenuReactView.openApp();
-  },
   continueInApp(extraData = null) {
     NativeModules.ShareMenuReactView.continueInApp(extraData);
   },
   data() {
     return NativeModules.ShareMenuReactView.data();
+  },
+  dismissExtension(error = null) {
+    NativeModules.ShareMenuReactView.dismissExtension(error);
+  },
+  isExtension: NativeModules.ShareMenuReactView.isExtension,
+  openApp() {
+    NativeModules.ShareMenuReactView.openApp();
   },
 };
 

--- a/ios/Modules/ShareMenuReactView.swift
+++ b/ios/Modules/ShareMenuReactView.swift
@@ -27,6 +27,11 @@ public class ShareMenuReactView: NSObject {
         ShareMenuReactView.viewDelegate = nil
     }
 
+    @objc
+    func constantsToExport() -> [String: Any]! {
+        return ["isExtension": ShareMenuReactView.viewDelegate?.loadExtensionContext() != nil]
+    }
+
     @objc(dismissExtension:)
     func dismissExtension(_ error: String?) {
         guard let extensionContext = ShareMenuReactView.viewDelegate?.loadExtensionContext() else {


### PR DESCRIPTION
When sharing code between a share extension and your main app it's useful to know whether or not you're executing within the share extension. This exposes the presence of the share extension context to RN via the boolean property `ShareMenuReactView.isExtension`.