### PR TITLE
Use rootProject SDK versions if available; bump defaults

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,22 @@
+buildscript {
+    ext {
+        rnsmDefaultTargetSdkVersion = 31
+        rnsmDefaultCompileSdkVersion = 31
+        rnsmDefaultMinSdkVersion = 21
+    }
+    ext.safeExtGet = {prop, fallback ->
+        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion safeExtGet('compileSdkVersion', rnsmDefaultCompileSdkVersion)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion safeExtGet('minSdkVersion', rnsmDefaultCompileSdkVersion)
+        targetSdkVersion safeExtGet('targetSdkVersion', rnsmDefaultCompileSdkVersion)
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
Fixes: https://github.com/Expensify/react-native-share-menu/issues/261

This updates to use the rootProject SDK versions if available [similar to react-native-screens](https://github.com/software-mansion/react-native-screens/blob/main/android/build.gradle#L47). It also bumps the default SDK versions up to match RN 0.68+