### PR TITLE
Gracefully handle HostAppURLScheme

### DIFF
--- a/IOS_INSTRUCTIONS.md
+++ b/IOS_INSTRUCTIONS.md
@@ -97,7 +97,7 @@ Add the following to your app's `Info.plist` (if you already had other URL Schem
         <key>CFBundleURLSchemes</key>
         <array>
             <string>A_URL_SCHEME_UNIQUE_TO_YOUR_APP</string>
-            <!-- This url scheme doesn't contain :// at the end - E.G. "mycustomscheme"-->
+            <!-- This URL scheme doesn't contain :// at the end - e.g. "mycustomscheme" -->
         </array>
     </dict>
 </array>
@@ -110,7 +110,7 @@ Add the following to your Share Extension's `Info.plist`:
 <string>YOUR_APP_TARGET_BUNDLE_ID</string>
 <key>HostAppURLScheme</key>
 <string>YOUR_APP_URL_SCHEME_DEFINED_ABOVE</string>
-<!-- This url scheme CONTAINS :// at the end - E.G. "mycustomscheme://"-->
+<!-- A URL with a scheme as defined in CFBundleURLSchemes above. Can be just the scheme or a more specific URL e.g. "mycustomscheme://share" -->
 <key>NSExtension</key>
 <dict>
     <key>NSExtensionAttributes</key>

--- a/ios/ShareViewController.swift
+++ b/ios/ShareViewController.swift
@@ -222,7 +222,7 @@ class ShareViewController: SLComposeServiceViewController {
       return
     }
     
-    let url = URL(string: urlScheme)
+    let url = URL(string: urlScheme.contains("://") ? urlScheme : "\(urlScheme)://")
     let selectorOpenURL = sel_registerName("openURL:")
     var responder: UIResponder? = self
     


### PR DESCRIPTION
We can handle adding `://` if it's not included here so let's make this easier on the user.

Before: `HostAppURLScheme` _must_ contain `://`
Now: `HostAppURLScheme` can match `CFBundleURLSchemes` exactly or contain `://` if you want to me more specific.