### PR TITLE
Fix detach view delegate

### DIFF
--- a/ios/Modules/ShareMenuReactView.swift
+++ b/ios/Modules/ShareMenuReactView.swift
@@ -45,6 +45,7 @@ public class ShareMenuReactView: NSObject {
         }
 
         extensionContext.completeRequest(returningItems: [], completionHandler: nil)
+        ShareMenuReactView.detachViewDelegate()
     }
 
     @objc
@@ -55,6 +56,7 @@ public class ShareMenuReactView: NSObject {
         }
 
         viewDelegate.openApp()
+        ShareMenuReactView.detachViewDelegate()
     }
 
     @objc(continueInApp:)
@@ -72,6 +74,7 @@ public class ShareMenuReactView: NSObject {
         }
 
         viewDelegate.continueInApp(with: items, and: extraData)
+        ShareMenuReactView.detachViewDelegate()
     }
 
     @objc(data:reject:)


### PR DESCRIPTION
Fixes: https://github.com/Expensify/react-native-share-menu/issues/230

Moving `detachViewDelegate` to `viewDidDisappear` [fixes swipe to dismiss](https://github.com/Expensify/react-native-share-menu/pull/81) but unfortunately it doesn't appear to get called consistently when leaving the share extension with `continueInApp`, `openApp`, or `dismissExtension`. This updates those methods to also `detachViewDelegate` fixing the subsequent crash on launch.