### PR TITLE
fix: correct broken import in ShareMenuManager.m

### DIFF
--- a/ios/ShareMenuManager.m
+++ b/ios/ShareMenuManager.m
@@ -6,7 +6,7 @@
 //
 
 #import "ShareMenuManager.h"
-#import "RNShareMenu-Swift.h"
+#import <RNShareMenu/RNShareMenu-Swift.h>
 
 #import <React/RCTLinkingManager.h>
 


### PR DESCRIPTION
My iOS builds failed to compile after installing `react-native-share-menu` because of `'RNShareMenu-Swift.h' file not found` errors. Changing the import from `"RNShareMenu-Swift.h"` to `<RNShareMenu/RNShareMenu-Swift.h>` fixed it.

Xcode: Version 15.1 (15C65)
React Native: 0.72.4
