### PR TITLE
Making the Android Installation more clear

### DIFF
--- a/ANDROID_INSTRUCTIONS.md
+++ b/ANDROID_INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # Android Installation
 
-## Manual Install
+## 1. Manual Install
 
 - In `android/settings.gradle`
 
@@ -40,7 +40,7 @@ public class MainApplication extends Application implements ReactApplication {
 ```
 
 
-## Add Intent Filter
+## 2. Add Intent Filter
 
 - In `android/app/src/main/AndroidManifest.xml` in the `<activity>` tag:
 

--- a/ANDROID_INSTRUCTIONS.md
+++ b/ANDROID_INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # Android Installation
 
-<details>
+##
 <summary>Manual Install</summary>
 
 - In `android/settings.gradle`
@@ -40,7 +40,6 @@ public class MainApplication extends Application implements ReactApplication {
 }
 ```
 
-</details>
 
 ## Add Intent Filter
 

--- a/ANDROID_INSTRUCTIONS.md
+++ b/ANDROID_INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # Android Installation
 
-## 1. Manual Install
+## Step 1. Manual Install
 
 - In `android/settings.gradle`
 
@@ -40,7 +40,7 @@ public class MainApplication extends Application implements ReactApplication {
 ```
 
 
-## 2. Add Intent Filter
+## Step 2. Add Intent Filter
 
 - In `android/app/src/main/AndroidManifest.xml` in the `<activity>` tag:
 

--- a/ANDROID_INSTRUCTIONS.md
+++ b/ANDROID_INSTRUCTIONS.md
@@ -1,7 +1,6 @@
 # Android Installation
 
-##
-<summary>Manual Install</summary>
+## Manual Install
 
 - In `android/settings.gradle`
 


### PR DESCRIPTION
Previously, the manual installation steps were hidden if using the `<details>` tag, which makes it really easy to miss that part. I've encountered the issues mentioned[@263](https://github.com/Expensify/react-native-share-menu/issues/263) because the steps weren't completed so ShareMenu in [this line](https://github.com/Expensify/react-native-share-menu/blob/cec3ac8f399c731898004761b93761a069c0d542/index.js#L3) is always null, which later causes [relevant calls](https://github.com/Expensify/react-native-share-menu/blob/cec3ac8f399c731898004761b93761a069c0d542/index.js#L32) to fail.