### PR TITLE
fix: vcard sharing in IOS fixed

### DIFF
--- a/ios/ShareViewController.swift
+++ b/ios/ShareViewController.swift
@@ -134,12 +134,17 @@ class ShareViewController: SLComposeServiceViewController {
         self.exit(withError: error.debugDescription)
         return
       }
-      guard let text = data as? String else {
-        self.exit(withError: COULD_NOT_FIND_STRING_ERROR)
+      guard let text = data as? NSData else{
+        guard let text = data as? String else {
+          self.exit(withError: COULD_NOT_FIND_STRING_ERROR)
+          return
+        }
+        self.sharedItems.append([DATA_KEY: text, MIME_TYPE_KEY: "text/plain"])
+        semaphore.signal()
         return
       }
-      
-      self.sharedItems.append([DATA_KEY: text, MIME_TYPE_KEY: "text/plain"])
+      let url = String(data: text as Data, encoding: .utf8)
+      self.sharedItems.append([DATA_KEY: url, MIME_TYPE_KEY: "vcard"])
       semaphore.signal()
     }
   }
@@ -246,3 +251,4 @@ class ShareViewController: SLComposeServiceViewController {
   }
 
 }
+


### PR DESCRIPTION
Allow sharing vcard in IOS.

Fixes:

[https://github.com/Expensify/react-native-share-menu/issues/235](https://github.com/Expensify/react-native-share-menu/pull/url)