### PR TITLE
Update IOS_INSTRUCTIONS.md for the setup instructions for React Native >0.71

### DIFF
--- a/IOS_INSTRUCTIONS.md
+++ b/IOS_INSTRUCTIONS.md
@@ -55,7 +55,7 @@ target '<PROJECT_NAME>' do
 end
 
 +target '<SHARE_EXTENSION_NAME>' do
-+  use_react_native!
++  use_react_native!(:flipper_configuration => flipper_config)
 +
 +  pod 'RNShareMenu', :path => '../node_modules/react-native-share-menu'
 +  # Manually link packages here to keep your extension bundle size minimal


### PR DESCRIPTION
Updates the setup instructions based on [this comment](https://github.com/Expensify/react-native-share-menu/issues/245#issuecomment-1460815189) to address [this issue](https://github.com/Expensify/react-native-share-menu/issues/245)